### PR TITLE
fix: prevent undefined index warning on login redirect

### DIFF
--- a/login/index.php
+++ b/login/index.php
@@ -18,9 +18,9 @@ if (!$userName)
 	<?endif?>
 </script>
 <?
-if (is_string($_REQUEST["backurl"]) && mb_strpos($_REQUEST["backurl"], "/") === 0)
+if (isset($_REQUEST["backurl"]) && is_string($_REQUEST["backurl"]) && mb_strpos($_REQUEST["backurl"], "/") === 0)
 {
-	LocalRedirect($_REQUEST["backurl"]);
+    LocalRedirect($_REQUEST["backurl"]);
 }
 
 $APPLICATION->SetTitle("Вход на сайт");


### PR DESCRIPTION
## Summary
- avoid undefined index warnings in login redirect logic

## Testing
- `php -l login/index.php`

------
https://chatgpt.com/codex/tasks/task_e_689cb032733083258ae93ddfdebbd5c1