### PR TITLE
feat: split consent and close actions

### DIFF
--- a/local/modules/ushakov.cookie/install/bitrix/css/ushakov.cookie/style.css
+++ b/local/modules/ushakov.cookie/install/bitrix/css/ushakov.cookie/style.css
@@ -35,16 +35,12 @@
     font-size: 14px
 }
 
-.ushakov-cookie img {
-    margin-left: 8px;
-    margin-top: 3px;
-    margin-bottom: 2px;
-    cursor: pointer;
-    width: 15px;
-    height: 15px;
+.ushakov-cookie__actions {
+    display: flex;
+    align-items: center;
 }
 
-.ushakov-cookie .button {
+.ushakov-cookie__accept {
     text-transform: uppercase;
     font-size: .8em;
     background: #0000007a;
@@ -53,14 +49,33 @@
     margin-left: 6px;
     cursor: pointer;
     user-select: none;
+    border: none;
+    color: inherit;
 }
 
-.ushakov-cookie .button:hover {
+.ushakov-cookie__accept:hover {
     background: #000000e3;
 }
 
-.ushakov-cookie img:hover {
-    opacity: .8
+.ushakov-cookie__close {
+    background: transparent;
+    border: none;
+    margin-left: 8px;
+    margin-top: 3px;
+    margin-bottom: 2px;
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+
+.ushakov-cookie__close img {
+    width: 15px;
+    height: 15px;
+}
+
+.ushakov-cookie__close:hover {
+    opacity: .8;
 }
 
 .ushakov-cookie a {

--- a/local/modules/ushakov.cookie/install/bitrix/js/ushakov.cookie/script.js
+++ b/local/modules/ushakov.cookie/install/bitrix/js/ushakov.cookie/script.js
@@ -94,21 +94,34 @@
 
     cookieText.innerHTML = options.text
 
-    // Вставляем или img, или span в зависимости от textButton
-    let closeElement
-    if (options.textButton && options.textButton.trim() !== '') {
-      closeElement = document.createElement('span')
-      closeElement.classList.add('button')
-      closeElement.textContent = options.textButton
-    } else {
-      closeElement = document.createElement('img')
-      closeElement.src = '/bitrix/images/ushakov.cookie/close.svg'
-    }
-    closeElement.onclick = sendCookieRequestAndRemoveElement
+    // блок с кнопками
+    const actionsWrapper = document.createElement('div')
+    actionsWrapper.className = 'ushakov-cookie__actions'
+
+    const acceptButton = document.createElement('button')
+    acceptButton.type = 'button'
+    acceptButton.className = 'ushakov-cookie__accept'
+    acceptButton.textContent = (options.textButton && options.textButton.trim() !== '') ? options.textButton : 'Принять'
+    acceptButton.setAttribute('aria-label', 'Принять cookies')
+    acceptButton.onclick = sendCookieRequestAndRemoveElement
+
+    const closeIcon = document.createElement('button')
+    closeIcon.type = 'button'
+    closeIcon.className = 'ushakov-cookie__close'
+    closeIcon.setAttribute('aria-label', 'Закрыть уведомление')
+    const closeImg = document.createElement('img')
+    closeImg.src = '/bitrix/images/ushakov.cookie/close.svg'
+    closeImg.alt = ''
+    closeImg.setAttribute('aria-hidden', 'true')
+    closeIcon.appendChild(closeImg)
+    closeIcon.onclick = hideCookieBanner
+
+    actionsWrapper.appendChild(acceptButton)
+    actionsWrapper.appendChild(closeIcon)
 
     // Собираем и вставляем в документ
     innerDiv.appendChild(cookieText)
-    innerDiv.appendChild(closeElement)
+    innerDiv.appendChild(actionsWrapper)
     cookieDiv.appendChild(innerDiv)
     document.body.appendChild(cookieDiv)
   }
@@ -137,5 +150,12 @@
         element.remove()
       }
     })
+  }
+
+  function hideCookieBanner () {
+    const element = document.getElementById('ushakov-cookie-wrap')
+    if (element) {
+      element.remove()
+    }
   }
 })();


### PR DESCRIPTION
## Summary
- add dedicated accept button and independent close icon
- improve accessibility by using semantic buttons and aria labels

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb44b5eac83258b8e6970e1f25be3